### PR TITLE
Fix duplicate jungletree node

### DIFF
--- a/node_defs.lua
+++ b/node_defs.lua
@@ -425,6 +425,7 @@ minetest.register_abm({
 -- we need our own copy of that node, which moretrees will match against.
 
 local jungle_tree = moretrees.clone_node("default:jungletree")
+jungle_tree["drop"] = "default:jungletree"
 minetest.register_node("moretrees:jungletree_trunk", jungle_tree)
 
 -- For compatibility with old nodes, recently-changed nodes, and default nodes


### PR DESCRIPTION
Fixed #30 by making the `moretrees:jungletree_trunk` node drop `default:jungletree`.

Maybe `not_in_creative_inventory` should be added too.